### PR TITLE
Update timeout from 60 to 120 seconds

### DIFF
--- a/cmd/speedtest_exporter/main.go
+++ b/cmd/speedtest_exporter/main.go
@@ -58,7 +58,7 @@ func main() {
 
 	http.Handle(metricsPath, promhttp.HandlerFor(r, promhttp.HandlerOpts{
 		MaxRequestsInFlight: 1,
-		Timeout:             60 * time.Second,
+		Timeout:             120 * time.Second,
 	}))
 	log.Fatal(http.ListenAndServe(":"+*port, nil))
 }


### PR DESCRIPTION
It appears to be possible to hit the timeout in normal operation, so I'm optimistically doubling it